### PR TITLE
chore : Park 패키지 구조 변경

### DIFF
--- a/Back-End/src/main/java/KBChallenge/BackEnd/PloggingMate/park/ParkController.java
+++ b/Back-End/src/main/java/KBChallenge/BackEnd/PloggingMate/park/ParkController.java
@@ -1,9 +1,9 @@
-package KBChallenge.BackEnd.PloggingMate.park.entity;
+package KBChallenge.BackEnd.PloggingMate.park;
 
 import KBChallenge.BackEnd.PloggingMate.configure.response.DataResponse;
 import KBChallenge.BackEnd.PloggingMate.configure.response.ResponseService;
-import KBChallenge.BackEnd.PloggingMate.park.entity.dto.CreateParkReq;
-import KBChallenge.BackEnd.PloggingMate.park.entity.dto.CreateParkRes;
+import KBChallenge.BackEnd.PloggingMate.park.dto.CreateParkRes;
+import KBChallenge.BackEnd.PloggingMate.park.dto.CreateParkReq;
 import KBChallenge.BackEnd.PloggingMate.util.ValidationExceptionProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.Errors;

--- a/Back-End/src/main/java/KBChallenge/BackEnd/PloggingMate/park/ParkRepository.java
+++ b/Back-End/src/main/java/KBChallenge/BackEnd/PloggingMate/park/ParkRepository.java
@@ -1,6 +1,7 @@
-package KBChallenge.BackEnd.PloggingMate.park.entity;
+package KBChallenge.BackEnd.PloggingMate.park;
 
 import KBChallenge.BackEnd.PloggingMate.configure.entity.Status;
+import KBChallenge.BackEnd.PloggingMate.park.entity.Park;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/Back-End/src/main/java/KBChallenge/BackEnd/PloggingMate/park/ParkService.java
+++ b/Back-End/src/main/java/KBChallenge/BackEnd/PloggingMate/park/ParkService.java
@@ -1,9 +1,10 @@
-package KBChallenge.BackEnd.PloggingMate.park.entity;
+package KBChallenge.BackEnd.PloggingMate.park;
 
 import KBChallenge.BackEnd.PloggingMate.configure.response.exception.CustomException;
 import KBChallenge.BackEnd.PloggingMate.configure.response.exception.CustomExceptionStatus;
-import KBChallenge.BackEnd.PloggingMate.park.entity.dto.CreateParkReq;
-import KBChallenge.BackEnd.PloggingMate.park.entity.dto.CreateParkRes;
+import KBChallenge.BackEnd.PloggingMate.park.dto.CreateParkRes;
+import KBChallenge.BackEnd.PloggingMate.park.dto.CreateParkReq;
+import KBChallenge.BackEnd.PloggingMate.park.entity.Park;
 import KBChallenge.BackEnd.PloggingMate.util.uploader.FirebaseFileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/Back-End/src/main/java/KBChallenge/BackEnd/PloggingMate/park/dto/CreateParkReq.java
+++ b/Back-End/src/main/java/KBChallenge/BackEnd/PloggingMate/park/dto/CreateParkReq.java
@@ -1,4 +1,4 @@
-package KBChallenge.BackEnd.PloggingMate.park.entity.dto;
+package KBChallenge.BackEnd.PloggingMate.park.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/Back-End/src/main/java/KBChallenge/BackEnd/PloggingMate/park/dto/CreateParkRes.java
+++ b/Back-End/src/main/java/KBChallenge/BackEnd/PloggingMate/park/dto/CreateParkRes.java
@@ -1,4 +1,4 @@
-package KBChallenge.BackEnd.PloggingMate.park.entity.dto;
+package KBChallenge.BackEnd.PloggingMate.park.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/Back-End/src/main/java/KBChallenge/BackEnd/PloggingMate/park/entity/Park.java
+++ b/Back-End/src/main/java/KBChallenge/BackEnd/PloggingMate/park/entity/Park.java
@@ -2,8 +2,6 @@ package KBChallenge.BackEnd.PloggingMate.park.entity;
 
 import KBChallenge.BackEnd.PloggingMate.configure.entity.BaseTimeEntity;
 import KBChallenge.BackEnd.PloggingMate.configure.entity.Status;
-import KBChallenge.BackEnd.PloggingMate.park.entity.dto.CreateParkReq;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/Back-End/src/main/java/KBChallenge/BackEnd/PloggingMate/post/PostService.java
+++ b/Back-End/src/main/java/KBChallenge/BackEnd/PloggingMate/post/PostService.java
@@ -6,21 +6,19 @@ import KBChallenge.BackEnd.PloggingMate.configure.response.exception.CustomExcep
 import KBChallenge.BackEnd.PloggingMate.configure.response.exception.CustomExceptionStatus;
 import KBChallenge.BackEnd.PloggingMate.configure.security.authentication.CustomUserDetails;
 import KBChallenge.BackEnd.PloggingMate.park.entity.Park;
-import KBChallenge.BackEnd.PloggingMate.park.entity.ParkRepository;
+import KBChallenge.BackEnd.PloggingMate.park.ParkRepository;
 import KBChallenge.BackEnd.PloggingMate.post.dto.PostListRes;
 import KBChallenge.BackEnd.PloggingMate.post.entity.AccountPostRelation;
 import KBChallenge.BackEnd.PloggingMate.post.dto.CreatePostReq;
 import KBChallenge.BackEnd.PloggingMate.post.entity.Post;
 import KBChallenge.BackEnd.PloggingMate.post.repository.AccountPostRelationRepository;
 import KBChallenge.BackEnd.PloggingMate.post.repository.PostRepository;
-import KBChallenge.BackEnd.PloggingMate.util.location.NaverDirection5;
 import KBChallenge.BackEnd.PloggingMate.util.location.NaverGeocode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 

--- a/Back-End/src/main/java/KBChallenge/BackEnd/PloggingMate/util/uploader/FirebaseFileService.java
+++ b/Back-End/src/main/java/KBChallenge/BackEnd/PloggingMate/util/uploader/FirebaseFileService.java
@@ -38,7 +38,7 @@ public class FirebaseFileService implements FileService {
             Credentials credentials = GoogleCredentials.fromStream(serviceAccount.getInputStream());
             storage = StorageOptions.newBuilder().setCredentials(credentials).build().getService();
         } catch (Exception e) {
-//            throw new CustomException(CustomExceptionStatus.SERVER_ERROR);
+            throw new CustomException(CustomExceptionStatus.SERVER_ERROR);
         }
     }
 

--- a/Back-End/src/test/java/KBChallenge/BackEnd/PloggingMate/microdust/MicrodustControllerTest.java
+++ b/Back-End/src/test/java/KBChallenge/BackEnd/PloggingMate/microdust/MicrodustControllerTest.java
@@ -33,7 +33,7 @@ class MicrodustControllerTest {
         userParam.add("tmX","212260.30360800");
         userParam.add("tmY","455168.10145573");
 
-        mockMvc.perform(get("/app/v1/microdust")
+        mockMvc.perform(get("/app/microdust")
                         .params(userParam)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
@@ -45,7 +45,7 @@ class MicrodustControllerTest {
     @Test
     public void testGetMicrodustInfoApiIfTmParamsNoPresent() throws Exception {
 
-        mockMvc.perform(get("/app/v1/microdust")
+        mockMvc.perform(get("/app/microdust")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                         .andExpect(status().isBadRequest())

--- a/Back-End/src/test/java/KBChallenge/BackEnd/PloggingMate/park/ParkControllerTest.java
+++ b/Back-End/src/test/java/KBChallenge/BackEnd/PloggingMate/park/ParkControllerTest.java
@@ -1,6 +1,6 @@
-package KBChallenge.BackEnd.PloggingMate.park.entity;
+package KBChallenge.BackEnd.PloggingMate.park;
 
-import KBChallenge.BackEnd.PloggingMate.park.entity.dto.CreateParkReq;
+import KBChallenge.BackEnd.PloggingMate.park.dto.CreateParkReq;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +13,8 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
+
+import java.nio.charset.StandardCharsets;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -33,13 +35,14 @@ class ParkControllerTest {
     @Test
     public void testCreateParkApi() throws Exception {
 
-        String content = objectMapper.writeValueAsString(new CreateParkReq("제102호 어린이공원","경기도 용인시 수지구 죽전동 1484번지 일원"));
         MockMultipartFile mockMultipartFile = new MockMultipartFile("file","제102호 어린이공원.jpg", "image/jpeg", "<<jpeg data>>".getBytes());
+        String content = objectMapper.writeValueAsString(new CreateParkReq("제102호 어린이공원","경기도 용인시 수지구 죽전동 1484번지 일원"));
+        MockMultipartFile mockContent = new MockMultipartFile("content","CreateParkReq","application/json",content.getBytes(StandardCharsets.UTF_8));
 
         mockMvc.perform(multipart("/app/park")
                 .file(mockMultipartFile)
-                .content(content)
-                .contentType(MediaType.APPLICATION_JSON)
+                .file(mockContent)
+                .contentType(MediaType.MULTIPART_MIXED)
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(print());

--- a/Back-End/src/test/java/KBChallenge/BackEnd/PloggingMate/park/ParkServiceTest.java
+++ b/Back-End/src/test/java/KBChallenge/BackEnd/PloggingMate/park/ParkServiceTest.java
@@ -1,7 +1,8 @@
-package KBChallenge.BackEnd.PloggingMate.park.entity;
+package KBChallenge.BackEnd.PloggingMate.park;
 
 import KBChallenge.BackEnd.PloggingMate.configure.response.exception.CustomException;
 import KBChallenge.BackEnd.PloggingMate.configure.response.exception.CustomExceptionStatus;
+import KBChallenge.BackEnd.PloggingMate.park.entity.Park;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
* chore : Park 패키지 구조 변경
- AccountPostRelation, Post를 /post/entity 패키지 내로 변경
- PostController, PostService를 /post 패키지 내로 변경

* chore : 테스트 코드 수정
- 미세먼지 API 테스트 코드에서 이전 url을 현재 url로 수정
- 공원 API 테스트 코드에서 RequestPart 적용